### PR TITLE
新增 dimit.core.channel.SortableChannelSelector

### DIFF
--- a/dimit-admin/pom.xml
+++ b/dimit-admin/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.github.dzh</groupId>
 		<artifactId>dimit</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>dimit-admin</artifactId>
 

--- a/dimit-core/pom.xml
+++ b/dimit-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.github.dzh</groupId>
 		<artifactId>dimit</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>dimit-core</artifactId>
 

--- a/dimit-core/src/main/java/dimit/core/channel/ChannelGroupWrapper.java
+++ b/dimit-core/src/main/java/dimit/core/channel/ChannelGroupWrapper.java
@@ -38,7 +38,7 @@ public class ChannelGroupWrapper implements StoreWrapper<ChannelGroup, ChannelGr
     private ChannelGroupWrapper(Dimiter dimiter) {
         this.dimiter = dimiter;
         channel = Collections.synchronizedList(new LinkedList<ChannelWrapper>());
-        selector = new SimpleChannelSelector(this);
+        selector = new SortableChannelSelector(this);
     }
 
     public static final ChannelGroupWrapper init(Dimiter dimiter, String cid) throws IOException {

--- a/dimit-core/src/main/java/dimit/core/channel/ChannelGroupWrapper.java
+++ b/dimit-core/src/main/java/dimit/core/channel/ChannelGroupWrapper.java
@@ -3,16 +3,6 @@
  */
 package dimit.core.channel;
 
-import java.io.IOException;
-import java.nio.file.WatchEvent;
-import java.nio.file.WatchKey;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import dimit.core.Dimiter;
 import dimit.core.StoreConst;
 import dimit.store.ChannelGroup;
@@ -23,6 +13,15 @@ import dimit.store.sys.Const;
 import dimit.store.sys.DimitPath;
 import dimit.store.sys.DimitStoreSystem;
 import dimit.store.util.IDUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author dzh
@@ -77,6 +76,10 @@ public class ChannelGroupWrapper implements StoreWrapper<ChannelGroup, ChannelGr
 
     public List<ChannelWrapper> select(String... tags) {
         return selector.select(tags);
+    }
+
+    public List<ChannelWrapper> select(String[] limitTags,String[] sortTags) {
+        return selector.select(limitTags,sortTags);
     }
 
     /**

--- a/dimit-core/src/main/java/dimit/core/channel/ChannelGroupWrapper.java
+++ b/dimit-core/src/main/java/dimit/core/channel/ChannelGroupWrapper.java
@@ -74,13 +74,10 @@ public class ChannelGroupWrapper implements StoreWrapper<ChannelGroup, ChannelGr
         return group;
     }
 
-    public List<ChannelWrapper> select(String... tags) {
-        return selector.select(tags);
+    public List<ChannelWrapper> select(ChannelSelectQuery query) {
+        return selector.select(query);
     }
 
-    public List<ChannelWrapper> select(String[] limitTags,String[] sortTags) {
-        return selector.select(limitTags,sortTags);
-    }
 
     /**
      * @param cid

--- a/dimit-core/src/main/java/dimit/core/channel/ChannelSelectQuery.java
+++ b/dimit-core/src/main/java/dimit/core/channel/ChannelSelectQuery.java
@@ -1,0 +1,28 @@
+package dimit.core.channel;
+
+import dimit.store.ChannelType;
+
+/**
+ * created by jiangt on 2018/04/25
+ */
+public abstract class ChannelSelectQuery {
+
+  private ChannelType channelType;
+
+
+  public ChannelSelectQuery(ChannelType channelType) {
+    this.channelType = channelType;
+  }
+
+  abstract String[] buildQuery();
+
+  public ChannelType getChannelType() {
+    return channelType;
+  }
+
+  public void setChannelType(ChannelType channelType) {
+    this.channelType = channelType;
+  }
+
+
+}

--- a/dimit-core/src/main/java/dimit/core/channel/ChannelSelector.java
+++ b/dimit-core/src/main/java/dimit/core/channel/ChannelSelector.java
@@ -3,10 +3,10 @@
  */
 package dimit.core.channel;
 
+import dimit.store.ChannelType;
+
 import java.io.Closeable;
 import java.util.List;
-
-import dimit.store.ChannelType;
 
 /**
  * <pre>
@@ -50,6 +50,12 @@ public abstract class ChannelSelector implements Closeable {
     }
 
     abstract List<ChannelWrapper> select(ChannelType type, String... tags);
+
+    public List<ChannelWrapper> select(String[] limitTag,String[] sortTag){
+        return select(ChannelType.SEND,limitTag,sortTag);
+    }
+
+    abstract List<ChannelWrapper> select(ChannelType type,String[] limitTag,String[] sortTag);
 
     public ChannelGroupWrapper group() {
         return this.group;

--- a/dimit-core/src/main/java/dimit/core/channel/ChannelSelector.java
+++ b/dimit-core/src/main/java/dimit/core/channel/ChannelSelector.java
@@ -3,8 +3,6 @@
  */
 package dimit.core.channel;
 
-import dimit.store.ChannelType;
-
 import java.io.Closeable;
 import java.util.List;
 
@@ -45,17 +43,7 @@ public abstract class ChannelSelector implements Closeable {
         this.group = group;
     }
 
-    public List<ChannelWrapper> select(String... tags) {
-        return select(ChannelType.SEND, tags);
-    }
-
-    abstract List<ChannelWrapper> select(ChannelType type, String... tags);
-
-        public List<ChannelWrapper> select(String[] hitTag,String[] sortTag){
-        return select(ChannelType.SEND,hitTag,sortTag);
-    }
-
-    abstract List<ChannelWrapper> select(ChannelType type,String[] hitTag,String[] sortTag);
+    public abstract List<ChannelWrapper> select(ChannelSelectQuery query);
 
     public ChannelGroupWrapper group() {
         return this.group;

--- a/dimit-core/src/main/java/dimit/core/channel/ChannelSelector.java
+++ b/dimit-core/src/main/java/dimit/core/channel/ChannelSelector.java
@@ -51,11 +51,11 @@ public abstract class ChannelSelector implements Closeable {
 
     abstract List<ChannelWrapper> select(ChannelType type, String... tags);
 
-    public List<ChannelWrapper> select(String[] limitTag,String[] sortTag){
-        return select(ChannelType.SEND,limitTag,sortTag);
+        public List<ChannelWrapper> select(String[] hitTag,String[] sortTag){
+        return select(ChannelType.SEND,hitTag,sortTag);
     }
 
-    abstract List<ChannelWrapper> select(ChannelType type,String[] limitTag,String[] sortTag);
+    abstract List<ChannelWrapper> select(ChannelType type,String[] hitTag,String[] sortTag);
 
     public ChannelGroupWrapper group() {
         return this.group;

--- a/dimit-core/src/main/java/dimit/core/channel/SimpleChannelQuery.java
+++ b/dimit-core/src/main/java/dimit/core/channel/SimpleChannelQuery.java
@@ -1,0 +1,25 @@
+package dimit.core.channel;
+
+import dimit.store.ChannelType;
+
+/**
+ * created by jiangt on 2018/04/25
+ */
+public class SimpleChannelQuery extends ChannelSelectQuery {
+
+  private String[] tags;
+
+  private SimpleChannelQuery(ChannelType channelType) {
+    super(channelType);
+  }
+
+  public SimpleChannelQuery(String[] tags) {
+    this(ChannelType.SEND);
+    this.tags = tags;
+  }
+
+  @Override
+  String[] buildQuery() {
+    return tags;
+  }
+}

--- a/dimit-core/src/main/java/dimit/core/channel/SimpleChannelSelector.java
+++ b/dimit-core/src/main/java/dimit/core/channel/SimpleChannelSelector.java
@@ -35,7 +35,9 @@ public class SimpleChannelSelector extends ChannelSelector {
     }
 
     @Override
-    List<ChannelWrapper> select(ChannelType type, String... tags) {
+    public List<ChannelWrapper> select(ChannelSelectQuery query) {
+        ChannelType type = query.getChannelType();
+        String[] tags = query.buildQuery();
         TreeSet<ChannelWrapper> primary = new TreeSet<>(new PriorityComparator());
         TreeSet<ChannelWrapper> standby = new TreeSet<>(new PriorityComparator());
 
@@ -68,10 +70,6 @@ public class SimpleChannelSelector extends ChannelSelector {
         return selected;
     }
 
-    @Override
-    List<ChannelWrapper> select(ChannelType type, String[] limitTag, String[] sortTag) {
-        return select(type,limitTag);
-    }
 
     class PriorityComparator implements Comparator<ChannelWrapper> {
 

--- a/dimit-core/src/main/java/dimit/core/channel/SimpleChannelSelector.java
+++ b/dimit-core/src/main/java/dimit/core/channel/SimpleChannelSelector.java
@@ -1,17 +1,16 @@
 package dimit.core.channel;
 
+import dimit.store.ChannelType;
+import dimit.store.conf.ChannelStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.TreeSet;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import dimit.store.ChannelType;
-import dimit.store.conf.ChannelStatus;
 
 /**
  * @author dzh
@@ -67,6 +66,11 @@ public class SimpleChannelSelector extends ChannelSelector {
         }
 
         return selected;
+    }
+
+    @Override
+    List<ChannelWrapper> select(ChannelType type, String[] limitTag, String[] sortTag) {
+        return select(type,limitTag);
     }
 
     class PriorityComparator implements Comparator<ChannelWrapper> {

--- a/dimit-core/src/main/java/dimit/core/channel/SortableChannelQuery.java
+++ b/dimit-core/src/main/java/dimit/core/channel/SortableChannelQuery.java
@@ -41,10 +41,12 @@ public class SortableChannelQuery extends ChannelSelectQuery {
 
   private String join(String... args) {
     StringBuilder sb = new StringBuilder();
-    for (String arg : args) {
-      sb.append(arg);
-      sb.append(",");
+    if (args != null) {
+      for (String arg : args) {
+        sb.append(arg);
+        sb.append(",");
+      }
     }
-    return sb.substring(0, sb.length() - 1);
+    return sb.toString();
   }
 }

--- a/dimit-core/src/main/java/dimit/core/channel/SortableChannelQuery.java
+++ b/dimit-core/src/main/java/dimit/core/channel/SortableChannelQuery.java
@@ -1,0 +1,50 @@
+package dimit.core.channel;
+
+import dimit.store.ChannelType;
+
+/**
+ * created by jiangt on 2018/04/25
+ */
+public class SortableChannelQuery extends ChannelSelectQuery {
+
+  private String[] hitTags;
+
+  private String[] sortTags;
+
+  public SortableChannelQuery(ChannelType channelType) {
+    super(channelType);
+  }
+
+  public SortableChannelQuery() {
+    this(ChannelType.SEND);
+  }
+
+  @Override
+  String[] buildQuery() {
+    return new String[]{join(hitTags),join(sortTags)};
+  }
+
+  public static SortableChannelQuery newQuery() {
+    return  new SortableChannelQuery();
+  }
+
+
+  public SortableChannelQuery hits(String... hitTags) {
+    this.hitTags = hitTags;
+    return this;
+  }
+
+  public SortableChannelQuery sort(String... sortTags) {
+    this.sortTags = sortTags;
+    return this;
+  }
+
+  private String join(String... args) {
+    StringBuilder sb = new StringBuilder();
+    for (String arg : args) {
+      sb.append(arg);
+      sb.append(",");
+    }
+    return sb.substring(0, sb.length() - 1);
+  }
+}

--- a/dimit-core/src/main/java/dimit/core/channel/SortableChannelSelector.java
+++ b/dimit-core/src/main/java/dimit/core/channel/SortableChannelSelector.java
@@ -12,7 +12,7 @@ import java.util.TreeSet;
 /**
  * select channel for channel group with the specified order.
  *
- * This selector will exclude the channel which is marked with limitTags then sort other channels
+ * This selector will exclude the channel which is not marked with hitTags then sort other channels
  * with tag in sortTags.The sort order will be same as the declare order in sortTags.If channels
  * were marked with same sortTags,the selector will use the default order strategy.
  *
@@ -33,12 +33,12 @@ public class SortableChannelSelector extends ChannelSelector {
 
   /**
    * @param type which type should be selected
-   * @param limitTag exclude channels with limit tag
+   * @param hitTag exclude channels with limit tag
    * @param sortTag order channels by sortTags
    * @return ordered channelWrapper list
    */
   @Override
-  List<ChannelWrapper> select(ChannelType type, String[] limitTag, String[] sortTag) {
+  List<ChannelWrapper> select(ChannelType type, String[] hitTag, String[] sortTag) {
     TreeSet<ChannelWrapper> filtered = new TreeSet<>(new SortTagsComparator(sortTag));
     List<ChannelWrapper> chans = group().channel();
     for (ChannelWrapper channel : chans) {
@@ -48,7 +48,7 @@ public class SortableChannelSelector extends ChannelSelector {
       if (!channel.isValid())
         continue;
 
-      if (!channel.cantainTags(limitTag))
+      if (!channel.cantainTags(hitTag))
         continue;
 
       filtered.add(channel);

--- a/dimit-core/src/main/java/dimit/core/channel/SortableChannelSelector.java
+++ b/dimit-core/src/main/java/dimit/core/channel/SortableChannelSelector.java
@@ -26,19 +26,13 @@ public class SortableChannelSelector extends ChannelSelector {
     super(group);
   }
 
-  @Override
-  List<ChannelWrapper> select(ChannelType type, String... tags) {
-    return select(type, tags, null);
-  }
 
-  /**
-   * @param type which type should be selected
-   * @param hitTag exclude channels with limit tag
-   * @param sortTag order channels by sortTags
-   * @return ordered channelWrapper list
-   */
   @Override
-  List<ChannelWrapper> select(ChannelType type, String[] hitTag, String[] sortTag) {
+  public List<ChannelWrapper> select(ChannelSelectQuery query) {
+    ChannelType type = query.getChannelType();
+    String[] tags = query.buildQuery();
+    String[] hitTag = tags[0].split(",");
+    String[] sortTag = tags[1].split(",");
     TreeSet<ChannelWrapper> filtered = new TreeSet<>(new SortTagsComparator(sortTag));
     List<ChannelWrapper> chans = group().channel();
     for (ChannelWrapper channel : chans) {

--- a/dimit-core/src/main/java/dimit/core/channel/SortableChannelSelector.java
+++ b/dimit-core/src/main/java/dimit/core/channel/SortableChannelSelector.java
@@ -1,0 +1,76 @@
+package dimit.core.channel;
+
+import dimit.store.ChannelType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.TreeSet;
+
+/**
+ * created by jiangt on 2018/04/24
+ */
+public class SortableChannelSelector extends ChannelSelector {
+
+  public SortableChannelSelector(ChannelGroupWrapper group) {
+    super(group);
+  }
+
+  @Override
+  List<ChannelWrapper> select(ChannelType type, String... tags) {
+    return select(type, tags, null);
+  }
+
+  @Override
+  List<ChannelWrapper> select(ChannelType type, String[] limitTag, String[] sortTag) {
+    TreeSet<ChannelWrapper> filtered = new TreeSet<>(new SortTagsComparator(sortTag));
+    List<ChannelWrapper> chans = group().channel();
+    for (ChannelWrapper channel : chans) {
+      if (channel.store().getType().getNumber() != type.getNumber()) {
+        continue;
+      }
+      if (!channel.isValid())
+        continue;
+
+      if (!channel.cantainTags(limitTag))
+        continue;
+
+      filtered.add(channel);
+    }
+    return new ArrayList<>(filtered);
+  }
+
+  @Override
+  public void close() throws IOException {
+
+  }
+
+  class SortTagsComparator implements Comparator<ChannelWrapper> {
+    private String[] sortTag;
+
+    public SortTagsComparator(String... sortTag) {
+      this.sortTag = sortTag;
+    }
+
+    @Override
+    public int compare(ChannelWrapper o1, ChannelWrapper o2) {
+      if (sortTag != null) {
+        for (String tag : sortTag) {
+          if (o1.cantainTags(tag) && !o2.cantainTags(tag)) {
+            return 1;
+          }
+          if (!o1.cantainTags(tag) && o2.cantainTags(tag)) {
+            return -1;
+          }
+        }
+      }
+      int p = o1.priority() - o2.priority();
+      if (p == 0) {
+        p = (int) (o1.tps() - o2.tps());
+      }
+      return p == 0 ? o1.id().compareTo(o2.id()) : p;
+    }
+  }
+
+}

--- a/dimit-demo/pom.xml
+++ b/dimit-demo/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.github.dzh</groupId>
 		<artifactId>dimit</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>dimit-demo</artifactId>
 	<dependencies>

--- a/dimit-demo/src/main/java/dimit/demo/DemoConst.java
+++ b/dimit-demo/src/main/java/dimit/demo/DemoConst.java
@@ -10,4 +10,7 @@ public interface DemoConst {
     String TAG_FIXED = "fixed";
     String TAG_MOBILE = "mobile";
 
+    String TAG_FIXED_CALLER = "fixed_caller";
+    String TAG_ONLY_CMCC ="only_cmcc";
+
 }

--- a/dimit-demo/src/test/java/dimit/demo/TestDimiterDemo.java
+++ b/dimit-demo/src/test/java/dimit/demo/TestDimiterDemo.java
@@ -1,5 +1,24 @@
 package dimit.demo;
 
+import dimit.core.Dimiter;
+import dimit.core.StoreConst;
+import dimit.core.channel.ChannelCallable;
+import dimit.core.channel.ChannelGroupWrapper;
+import dimit.core.channel.ChannelWrapper;
+import dimit.core.channel.SortableChannelSelector;
+import dimit.demo.dimiter.DimiterDemo;
+import dimit.demo.store.TestZkStoreConfDemo;
+import dimit.store.ChannelType;
+import dimit.store.conf.ChannelConf;
+import dimit.store.conf.ChannelStatus;
+import dimit.store.sys.DimitPath;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -11,25 +30,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import dimit.core.Dimiter;
-import dimit.core.StoreConst;
-import dimit.core.channel.ChannelCallable;
-import dimit.core.channel.ChannelGroupWrapper;
-import dimit.core.channel.ChannelWrapper;
-import dimit.demo.dimiter.DimiterDemo;
-import dimit.demo.store.TestZkStoreConfDemo;
-import dimit.store.ChannelType;
-import dimit.store.conf.ChannelConf;
-import dimit.store.conf.ChannelStatus;
-import dimit.store.sys.DimitPath;
 
 /**
  * @author dzh
@@ -48,7 +48,7 @@ public class TestDimiterDemo {
     public static void init() {
         try {
             Map<String, Object> env = new HashMap<>();
-            env.put(StoreConst.P_CHANNEL_SELECTOR, "");
+            env.put(StoreConst.P_CHANNEL_SELECTOR, SortableChannelSelector.class.getName());
 
             demo = new DimiterDemo("dimit-zk://dzh/dimit?host=127.0.0.1:2181&sleep=1000&retry=3", env, "voice");
             // 初始化通道组
@@ -92,6 +92,11 @@ public class TestDimiterDemo {
         // LOG.info("select only fixed {}", selected); // 21002 21001
         selected = demo.dimiter().dimit().group(group.id()).select(DemoConst.TAG_MOBILE);
         LOG.info("select only mobile {}", selected); // 21001 21003
+
+        selected  = demo.dimiter().dimit().group(group.id()).selector().select(
+          new String[]{DemoConst.TAG_MOBILE},new String[]{DemoConst.TAG_ONLY_CMCC}
+        );
+        LOG.info("select with sort[tag:{}] {}",DemoConst.TAG_ONLY_CMCC,selected);
 
         // invalid 21001
         DimitPath path21001 = demo.dimiter().storeSystem().getPath("conf", "voice", "vcode", "21001");

--- a/dimit-demo/src/test/java/dimit/demo/TestDimiterDemo.java
+++ b/dimit-demo/src/test/java/dimit/demo/TestDimiterDemo.java
@@ -5,6 +5,7 @@ import dimit.core.StoreConst;
 import dimit.core.channel.ChannelCallable;
 import dimit.core.channel.ChannelGroupWrapper;
 import dimit.core.channel.ChannelWrapper;
+import dimit.core.channel.SortableChannelQuery;
 import dimit.core.channel.SortableChannelSelector;
 import dimit.demo.dimiter.DimiterDemo;
 import dimit.demo.store.TestZkStoreConfDemo;
@@ -82,7 +83,7 @@ public class TestDimiterDemo {
      * @throws InterruptedException
      */
     @Test
-    @Ignore
+//    @Ignore
     public void testSelectChannel() throws IOException, InterruptedException {
         // select channel
         List<ChannelWrapper> selected = null;
@@ -90,12 +91,13 @@ public class TestDimiterDemo {
         // LOG.info("select fixed and mobile {}", selected); // 21001
         // selected = demo.dimiter().getDimit().group(group.id()).select(DemoConst.TAG_FIXED);
         // LOG.info("select only fixed {}", selected); // 21002 21001
-        selected = demo.dimiter().dimit().group(group.id()).select(DemoConst.TAG_MOBILE);
+        SortableChannelQuery query = SortableChannelQuery.newQuery().hits(DemoConst
+          .TAG_FIXED_CALLER);
+        selected = demo.dimiter().dimit().group(group.id()).select(query);
         LOG.info("select only mobile {}", selected); // 21001 21003
 
-        selected  = demo.dimiter().dimit().group(group.id()).selector().select(
-          new String[]{DemoConst.TAG_MOBILE},new String[]{DemoConst.TAG_ONLY_CMCC}
-        );
+        query.hits(DemoConst.TAG_MOBILE).sort(DemoConst.TAG_ONLY_CMCC);
+        selected  = demo.dimiter().dimit().group(group.id()).selector().select(query);
         LOG.info("select with sort[tag:{}] {}",DemoConst.TAG_ONLY_CMCC,selected);
 
         // invalid 21001
@@ -108,7 +110,8 @@ public class TestDimiterDemo {
         Thread.sleep(1000L); // TODO
 
         // select channel
-        selected = demo.dimiter().dimit().group(group.id()).select(DemoConst.TAG_MOBILE);
+        query.hits(DemoConst.TAG_MOBILE).sort(null);
+        selected = demo.dimiter().dimit().group(group.id()).select(query);
         LOG.info("select only mobile {}", selected); // 21003
 
         // valid 21001
@@ -124,7 +127,9 @@ public class TestDimiterDemo {
     @Ignore
     public void testUpdateTps() throws IOException, InterruptedException {
         List<ChannelWrapper> selected = null;
-        selected = demo.dimiter().dimit().group(group.id()).select(DemoConst.TAG_FIXED, DemoConst.TAG_MOBILE);
+        SortableChannelQuery query = SortableChannelQuery.newQuery().hits(DemoConst.TAG_FIXED,
+          DemoConst.TAG_MOBILE);
+        selected = demo.dimiter().dimit().group(group.id()).select(query);
         LOG.info("select only mobile {}", selected); // 21001
         if (!selected.isEmpty()) {
             LOG.info("tps {}", selected.get(0).tps()); // 2.0
@@ -138,7 +143,7 @@ public class TestDimiterDemo {
         demo.dimiter().storeSystem().io().write(path21001, conf21001); // 1.0
         Thread.sleep(1000L);
 
-        selected = demo.dimiter().dimit().group(group.id()).select(DemoConst.TAG_FIXED, DemoConst.TAG_MOBILE);
+        selected = demo.dimiter().dimit().group(group.id()).select(query);
         LOG.info("select only mobile {}", selected); // 21001
         if (!selected.isEmpty()) {
             LOG.info("tps {} {}", selected.get(0).tps(), selected.get(0).isValid()); // 1.0
@@ -150,7 +155,7 @@ public class TestDimiterDemo {
         demo.dimiter().storeSystem().io().write(path21001, conf21001); // 0.5
         Thread.sleep(1000L);
 
-        selected = demo.dimiter().dimit().group(group.id()).select(DemoConst.TAG_FIXED, DemoConst.TAG_MOBILE);
+        selected = demo.dimiter().dimit().group(group.id()).select(query);
         LOG.info("select only mobile {}", selected); //
         if (!selected.isEmpty()) {
             LOG.info("tps {} {}", selected.get(0).tps(), selected.get(0).isValid());
@@ -171,7 +176,9 @@ public class TestDimiterDemo {
 
         // select channel
         List<ChannelWrapper> selected = null;
-        selected = demo.dimiter().dimit().group(group.id()).select(DemoConst.TAG_FIXED, DemoConst.TAG_MOBILE);
+        SortableChannelQuery query = SortableChannelQuery.newQuery().hits(DemoConst.TAG_FIXED,
+          DemoConst.TAG_MOBILE);
+        selected = demo.dimiter().dimit().group(group.id()).select(query);
 
         if (!selected.isEmpty()) {
             final ChannelWrapper ch = selected.get(0);
@@ -210,7 +217,7 @@ public class TestDimiterDemo {
                     demo.dimiter().storeSystem().io().write(path21001, conf21001); // 1.0
                     Thread.sleep(1000L);
 
-                    selected = demo.dimiter().dimit().group(group.id()).select(DemoConst.TAG_FIXED, DemoConst.TAG_MOBILE);
+                    selected = demo.dimiter().dimit().group(group.id()).select(query);
                     LOG.info("select only mobile {}", selected); // 21001
                     if (!selected.isEmpty()) {
                         LOG.info("tps {} {}", selected.get(0).tps(), selected.get(0).isValid()); // 1.0
@@ -239,7 +246,8 @@ public class TestDimiterDemo {
         ExecutorService es = Executors.newFixedThreadPool(2);
 
         // select channel
-        final List<ChannelWrapper> selected = demo.dimiter().dimit().group(group.id()).select(DemoConst.TAG_MOBILE);
+        SortableChannelQuery query = SortableChannelQuery.newQuery().hits(DemoConst.TAG_MOBILE);
+        final List<ChannelWrapper> selected = demo.dimiter().dimit().group(group.id()).select(query);
         if (!selected.isEmpty()) {
             final AtomicInteger execCount = new AtomicInteger(0);
             int forCount = 1000;

--- a/dimit-demo/src/test/java/dimit/demo/store/TestZkStoreConfDemo.java
+++ b/dimit-demo/src/test/java/dimit/demo/store/TestZkStoreConfDemo.java
@@ -1,18 +1,17 @@
 package dimit.demo.store;
 
-import java.io.IOException;
-import java.util.Arrays;
-
+import dimit.demo.DemoConst;
+import dimit.store.conf.ChannelStatus;
+import dimit.store.conf.DimitConf;
+import dimit.store.sys.DimitPath;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import dimit.demo.DemoConst;
-import dimit.store.conf.ChannelStatus;
-import dimit.store.conf.DimitConf;
-import dimit.store.sys.DimitPath;
+import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * 初始化测试数据
@@ -52,7 +51,7 @@ public class TestZkStoreConfDemo {
     @Test
     public void createChannelConf_1() throws IOException {
         DimitPath path = zkStore.createChannelConf("voice", "vcode", "21001", "ch1", ChannelStatus.PRIMARY, 10, 100f,
-                Arrays.asList(DemoConst.TAG_FIXED, DemoConst.TAG_MOBILE));
+                Arrays.asList(DemoConst.TAG_FIXED, DemoConst.TAG_MOBILE,DemoConst.TAG_ONLY_CMCC));
 
         DimitConf dimitConf = path.<DimitConf> toStore(DimitConf.class);
         LOG.info("read dimit {} {}", path, dimitConf);
@@ -61,7 +60,7 @@ public class TestZkStoreConfDemo {
     @Test
     public void createChannelConf_2() throws IOException {
         DimitPath path = zkStore.createChannelConf("voice", "vcode", "21002", "ch2", ChannelStatus.PRIMARY, 8, 100f,
-                Arrays.asList(DemoConst.TAG_FIXED));
+                Arrays.asList(DemoConst.TAG_FIXED,DemoConst.TAG_ONLY_CMCC));
 
         DimitConf dimitConf = path.<DimitConf> toStore(DimitConf.class);
         LOG.info("read dimit {} {}", path, dimitConf);
@@ -70,7 +69,7 @@ public class TestZkStoreConfDemo {
     @Test
     public void createChannelConf_3() throws IOException {
         DimitPath path = zkStore.createChannelConf("voice", "vcode", "21003", "ch3", ChannelStatus.STANDBY, 8, 100f,
-                Arrays.asList(DemoConst.TAG_MOBILE));
+                Arrays.asList(DemoConst.TAG_MOBILE,DemoConst.TAG_FIXED_CALLER,DemoConst.TAG_ONLY_CMCC));
 
         DimitConf dimitConf = path.<DimitConf> toStore(DimitConf.class);
         LOG.info("read dimit {} {}", path, dimitConf);

--- a/dimit-redis/pom.xml
+++ b/dimit-redis/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.github.dzh</groupId>
     <artifactId>dimit</artifactId>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>0.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>dimit-redis</artifactId>
 </project>

--- a/dimit-store/pom.xml
+++ b/dimit-store/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.github.dzh</groupId>
 		<artifactId>dimit</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>dimit-store</artifactId>
 

--- a/dimit-zk/pom.xml
+++ b/dimit-zk/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.github.dzh</groupId>
 		<artifactId>dimit</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>dimit-zk</artifactId>
 

--- a/doc/release_note.md
+++ b/doc/release_note.md
@@ -1,7 +1,10 @@
 发布记录
 ==========================
 
-## v0.0.3 TODO 2018-
+## v0.0.4 2018-04-25
+- 新增`dimit.core.channel.SortableChannelSelector` 可以在选择通道时支持排序
+
+## v0.0.3  2018-
 - 新增`channel.selector` 自定义ChannelSelector
 
 TODO

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.dzh</groupId>
 	<artifactId>dimit</artifactId>
-	<version>0.0.3-SNAPSHOT</version>
+	<version>0.0.4-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>


### PR DESCRIPTION
新增加了一个通道筛选器 dimit.core.channel.SortableChannelSelector 
抽象父类 dimit.core.channel.ChannelSelector 中增加了两个方法
1.List<ChannelWrapper> select(String[] limitTag,String[] sortTag)
2.List<ChannelWrapper> select(ChannelType type,String[] limitTag,String[] sortTag)——抽象方法
排序策略 
标记 > 主备 > 优先级 > tps >通道id
![image](https://user-images.githubusercontent.com/13410247/39232695-b863ef76-48a0-11e8-8ca1-529a48b92960.png)
